### PR TITLE
fix: plugin.platforms key

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,9 +25,10 @@ flutter:
   # be modified. They are used by the tooling to maintain consistency when
   # adding or updating assets for this project.
   plugin:
-    android:
-      package: io.github.kdy1.open_noti_settings
-      pluginClass: OpenNotiSettingsPlugin
+    platforms:
+      android:
+        package: io.github.kdy1.open_noti_settings
+        pluginClass: OpenNotiSettingsPlugin
   # To add assets to your plugin package, add an assets section, like this:
   # assets:
   #  - images/a_dot_burr.jpeg

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: open_noti_settings
 description: A plugin to open notification settings
-version: 0.0.3
+version: 0.0.4
 homepage: https://github.com/kdy1/flutter_open_notification_settings
 
 environment:


### PR DESCRIPTION
Hey there again :-)
thank you so much for publishing the package. Unfortenetly I now get this error when running `flutter analyze`:
```
Invalid plugin specification open_noti_settings.
Cannot find the `flutter.plugin.platforms` key in the `pubspec.yaml` file. An instruction to format the `pubspec.yaml` can be
found here: https://flutter.dev/docs/development/packages-and-plugins/developing-packages#plugin-platforms
```

Looks like the platforms key was missing in the pubspec.yaml and here is the fix for this :)

Best regards and stay healthy