### PR TITLE
refactor: Migrate to null safety

### DIFF
--- a/lib/open_noti_settings.dart
+++ b/lib/open_noti_settings.dart
@@ -29,21 +29,21 @@ class NotificationSetting {
       NotificationDetails notificationDetails) {
     Map<String, dynamic> serializedPlatformSpecifics;
     serializedPlatformSpecifics = {
-      'channelId': notificationDetails?.android?.channelId,
-      'channelName': notificationDetails?.android?.channelName,
-      'channelDescription': notificationDetails?.android?.channelDescription,
-      'importance': notificationDetails?.android?.importance?.value,
-      'groupKey': notificationDetails?.android?.groupKey,
-      'playSound': notificationDetails?.android?.playSound,
-      'sound': notificationDetails?.android?.sound?.toString(),
-      'enableVibration': notificationDetails?.android?.enableVibration,
-      'vibrationPattern': notificationDetails?.android?.vibrationPattern,
-      'enableLights': notificationDetails?.android?.enableLights,
-      'ledColorRed': notificationDetails?.android?.ledColor?.red,
-      'ledColorGreen': notificationDetails?.android?.ledColor?.green,
-      'ledColorBlue': notificationDetails?.android?.ledColor?.blue,
-      'ledColorAlpha': notificationDetails?.android?.ledColor?.alpha,
-      'channelShowBadge': notificationDetails?.android?.channelShowBadge,
+      'channelId': notificationDetails.android?.channelId,
+      'channelName': notificationDetails.android?.channelName,
+      'channelDescription': notificationDetails.android?.channelDescription,
+      'importance': notificationDetails.android?.importance.value,
+      'groupKey': notificationDetails.android?.groupKey,
+      'playSound': notificationDetails.android?.playSound,
+      'sound': notificationDetails.android?.sound?.toString(),
+      'enableVibration': notificationDetails.android?.enableVibration,
+      'vibrationPattern': notificationDetails.android?.vibrationPattern,
+      'enableLights': notificationDetails.android?.enableLights,
+      'ledColorRed': notificationDetails.android?.ledColor?.red,
+      'ledColorGreen': notificationDetails.android?.ledColor?.green,
+      'ledColorBlue': notificationDetails.android?.ledColor?.blue,
+      'ledColorAlpha': notificationDetails.android?.ledColor?.alpha,
+      'channelShowBadge': notificationDetails.android?.channelShowBadge,
     };
     return serializedPlatformSpecifics;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,7 @@ version: 0.3.0
 homepage: https://github.com/kdy1/flutter_open_notification_settings
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
-  flutter: ">= 1.10.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
This is the first step to fix this plugin for the new Flutter version. It does not yet fix the Android migration warning but migrates it to null safety at least.

I have not tested this in production but the changes are very small so it should not break anything (famous last words).